### PR TITLE
#minor remove of unnecessary /static/ folder and use of the upper level

### DIFF
--- a/.github/workflows/build-and-deploy-to-scaleway.yaml
+++ b/.github/workflows/build-and-deploy-to-scaleway.yaml
@@ -38,10 +38,10 @@ jobs:
           BACKEND_BASE_URL: ''
           STATIC_FILES_URL: 'https://reacteasyssrjckf9fbl-reacteasyssrstatic.functions.fnc.fr-par.scw.cloud'
 
-      - name: Copy past new static files
+      - name: Copy past client static files
         uses: canastro/copy-file-action@master
         with:
-          source: dist/client/static/.
+          source: dist/client/.
           target: public/static/
           flags: '-r'
 

--- a/public/Dockerfile
+++ b/public/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /var/www
 
 COPY nginx.conf /etc/nginx/nginx.conf
 
-COPY ./static ./static
+COPY ./static .
 
 CMD sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/nginx.conf && nginx -g 'daemon off;'

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -66,7 +66,7 @@ const start = async () => {
 
     const script = nodemon({
       script: `${paths.serverBuild}/index.js`,
-      ignore: ['src', 'webpack', 'scripts', 'dist/client'],
+      ignore: ['src', 'webpack', 'scripts', `${paths.clientBuild}`, 'public', 'node_modules'], // We just want paths.serverBuild to be watched
       delay: 200
     })
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -5,7 +5,7 @@ const appDirectory = fs.realpathSync(process.cwd())
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath)
 const paths = {
   dist: resolveApp('dist'),
-  publicPath: '/static/',
+  publicPath: '/',
   clientBuild: resolveApp('dist/client'),
   serverBuild: resolveApp('dist/server'),
   srcClient: resolveApp('src/index.tsx'),

--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -45,14 +45,13 @@ if (process.env.NODE_ENV === 'production') {
 
 if (process.env.NODE_ENV === 'development' || (!process.env.STATIC_FILES_URL && process.env.NODE_ENV === 'production')) {
   /**
-   * This line is only used in development mode
+   * This middleware is only used in development mode
    * In production mode we separate static files from the main Express.js frontend server
    * By separating them, you discharge tensions on this Express.js frontend server
-   * It now depends what kind of router you are using, Nginx my favorite, Traefik. The rule
-   * is to make a redirection for example like this https://reacteasyssrjckf9fbl-reacteasyssrstatic.functions.fnc.fr-par.scw.cloud/static/15.bundle-832a294529dcad5060bd.js
+   * It now depends what kind of router you are using, Nginx my favorite, Traefik. The best
+   * thing to do is to create a domain alias static, and make a CNAME rediction to it, like
+   * for example https://static.mywebsite.com/15.bundle-832a294529dcad5060bd.js
    * and now the static bundle file 15.bundle-832a294529dcad5060bd.js is served.
-   * In order to achieve this you need a good CI which will do npm run build, then copy the build into an other
-   * docker container to serve it through /static/ path
    */
   app.use(paths.publicPath, express.static(path.join(paths.clientBuild, paths.publicPath)))
 }

--- a/src/server/renderFullPage.ts
+++ b/src/server/renderFullPage.ts
@@ -17,7 +17,7 @@ const renderFullPage = (
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <link rel="stylesheet" type="text/css" href="${
-      process.env.STATIC_FILES_URL ? `${process.env.STATIC_FILES_URL}/static/bundle.css` : `/static/bundle.css`
+      process.env.STATIC_FILES_URL ? `${process.env.STATIC_FILES_URL}/bundle.css` : `/bundle.css`
     }" />
     
     ${helmet?.title?.toString()}


### PR DESCRIPTION
`/dist/client/static/` folder can be confusing, because `client` folder will always contain static files.

This is just a remove of the `static` folder as publicPath in the webpack compilation, however we keep it as basis for Nginx `/public/static/`.